### PR TITLE
 add support for zita_convolver4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,17 @@
 
 # Issue 'make convert4chan' to compile the 4-channel converter utility
 # (for local use, not installed by make install)
+	# check if user is root
 
+BUNDLE = ir.lv2
 PREFIX ?= /usr
-INSTDIR = $(DESTDIR)$(PREFIX)/lib/lv2/ir.lv2
+
+user = $(shell whoami)
+ifeq ($(user),root)
+INSTDIR = $(DESTDIR)$(PREFIX)/lib/lv2/$(BUNDLE)
+else 
+INSTDIR = ~/.lv2/$(BUNDLE)
+endif
 
 INST_FILES = ir.so ir_gui.so ir.ttl manifest.ttl
 
@@ -59,3 +67,6 @@ install: all
 
 clean:
 	rm -f *~ *.o ir.so ir_gui.so convert4chan
+
+uninstall :
+	rm -rf $(INSTDIR)/$(BUNDLE)


### PR DESCRIPTION
Hi

This patch add support for the newest zita-convolver 4 library.
Additional I've add the possibility to install as user to ~/.lv2 and a uninstall target to the makefile. 