### PR TITLE
 add support for zita_convolver_4 as well to zero-latency branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,15 @@
 # Issue 'make convert4chan' to compile the 4-channel converter utility
 # (for local use, not installed by make install)
 
+BUNDLE = ir.lv2
 PREFIX ?= /usr
-INSTDIR = $(DESTDIR)$(PREFIX)/lib/lv2/ir.lv2
+
+user = $(shell whoami)
+ifeq ($(user),root)
+INSTDIR ?= $(DESTDIR)$(PREFIX)/lib/lv2/$(BUNDLE)
+else 
+INSTDIR ?= ~/.lv2/$(BUNDLE)
+endif
 
 INST_FILES = ir.so ir_gui.so ir.ttl manifest.ttl
 
@@ -59,3 +66,6 @@ install: all
 
 clean:
 	rm -f *~ *.o ir.so ir_gui.so convert4chan
+
+uninstall :
+	rm -rf $(INSTDIR)/$(BUNDLE)

--- a/ir.cc
+++ b/ir.cc
@@ -33,10 +33,17 @@
 #include "ir.h"
 #include "ir_utils.h"
 
-#if ZITA_CONVOLVER_MAJOR_VERSION != 3
-#error "This version of IR requires zita-convolver 3.x.x"
+#define ZITA_CONVOLVER_VERSION  0
+#if ZITA_CONVOLVER_MAJOR_VERSION == 3
+#undef ZITA_CONVOLVER_VERSION
+#define ZITA_CONVOLVER_VERSION  3
+#elif ZITA_CONVOLVER_MAJOR_VERSION == 4
+#undef ZITA_CONVOLVER_VERSION
+#define ZITA_CONVOLVER_VERSION  4
+#else
+#error "This version of zita-convolver isn't supported or not found"
 #endif
- 
+
 /* You may need to change these to match your JACK server setup!
  *
  * Priority should match -P parameter passed to jackd.
@@ -512,16 +519,29 @@ void init_conv(IR * ir) {
 	}
 
 	G_LOCK(conv_configure_lock);
+#if ZITA_CONVOLVER_VERSION == 3
 	if (ir->nchan == 4) {
 		conv->set_density(1);
 	}
-	//printf("configure length=%d ir->block_length=%d\n", length, ir->block_length);
 	int ret = conv->configure(2, // n_inputs
 				  2, // n_outputs
 				  length,
 				  ir->block_length,
 				  ir->block_length,
 				  Convproc::MAXPART);
+#elif ZITA_CONVOLVER_VERSION == 4
+	float density = 0.0;
+	if (ir->nchan == 4) {
+		density = 1.0;
+	}
+	int ret = conv->configure(2, // n_inputs
+				  2, // n_outputs
+				  length,
+				  ir->block_length,
+				  ir->block_length,
+				  Convproc::MAXPART,
+				  density);
+#endif
 	G_UNLOCK(conv_configure_lock);
 	if (ret != 0) {
 		fprintf(stderr, "IR: can't initialise zita-convolver engine, Convproc::configure returned %d\n", ret);


### PR DESCRIPTION
I've forgotten to add support for zita-convolver 4 to the zero-latency branch, here it is.